### PR TITLE
filter to prevent multiple occurences of the same station in a coinciden...

### DIFF
--- a/sapphire/analysis/coincidences.py
+++ b/sapphire/analysis/coincidences.py
@@ -404,16 +404,21 @@ class Coincidences(object):
         # traverse all timestamps
         prev_coincidence = []
         for i in xrange(len(timestamps)):
+            stations_hit = []
 
             # build coincidence, starting with the current timestamp
             c = [i]
             t0 = timestamps[i][0]
 
+            stations_hit.append(timestamps[i][1])
+
             # traverse the rest of the timestamps
             for j in xrange(i + 1, len(timestamps)):
                 # if a timestamp is within the coincidence window, add it
                 if timestamps[j][0] - t0 < window:
-                    c.append(j)
+                    if timestamps[j][1] not in stations_hit:
+                        stations_hit.append(timestamps[j][1])
+                        c.append(j)
                 else:
                     # coincidence window has passed, break for-loop
                     break


### PR DESCRIPTION
If the same station occurs more tan once in a coincidence, it can happen that the same station acts twice in a triple for direction reconstruction. This leads to ' division by zero'  error (because phi1 = phi 2). To change is to prevent this error. A consequence of the change is that the single coincidence with more than once the same station is replaced by more than one coincidences with a station occuring only once in each coincidence. 

@davidfokkema @153957 
