### PR TITLE
PyTables conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 # https://gist.github.com/dan-blanchard/7045057
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libhdf5-serial-dev
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
   - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh


### PR DESCRIPTION
Speed up Travis builds

Install PyTables, numexpr and HDF5 with conda.
Did not do this sooner because of reports that PyTables install failed with conda, but it seems to be working now.

Before these changes it took between 3 min 30 sec and 5 min 11 sec.
With these changes a build takes around 2 min 30 sec

Build 46 and 47 are with these changes:
https://travis-ci.org/HiSPARC/sapphire/builds
