### PR TITLE
Add flake8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,12 @@ before_install:
 
 install:
   - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pytables matplotlib
-  - pip install coverage coveralls
+  - pip install coverage coveralls flake8
   - python setup.py develop
 
 script:
   - coverage run --source=sapphire setup.py test
+  - flake8 --ignore=E501 sapphire
 
 after_success:
   coveralls


### PR DESCRIPTION
Partly related to #45.

This adds PEP8 and pyflakes testing.
flake8 helps find simple bugs, see 7629461bc2.

However, we sometimes intentionally break PEP8 rules.
I do not want to add exceptions for each case, nor ignore all those rules entirely.

Perhaps just report the results from flake8 but ignore the returned status?