### PR TITLE
4 dimensional stations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
 
+sudo: false
+
 addons:
   apt_packages:
     - libatlas-dev

--- a/sapphire/analysis/direction_reconstruction.py
+++ b/sapphire/analysis/direction_reconstruction.py
@@ -114,10 +114,6 @@ class CoincidenceDirectionReconstruction(object):
         self.fit = RegressionAlgorithm3D
         self.cluster = cluster
 
-        for station in self.cluster.stations:
-            station.center_of_mass_coordinates = \
-                station.calc_center_of_mass_coordinates()
-
     def reconstruct_coincidence(self, coincidence_events, station_numbers=None,
                                 offsets={}):
         """Reconstruct a single coincidence

--- a/sapphire/analysis/direction_reconstruction.py
+++ b/sapphire/analysis/direction_reconstruction.py
@@ -149,7 +149,7 @@ class CoincidenceDirectionReconstruction(object):
                     continue
             t_off = offsets.get(station_number, no_offset)
             station = self.cluster.get_station(station_number)
-            t_first = station_arrival_time(event, ts0, offsets=t_off,
+            t_first = station_arrival_time(event, ets0, offsets=t_off,
                                            station=station)
             if not isnan(t_first):
                 sx, sy, sz = station.calc_center_of_mass_coordinates()

--- a/sapphire/analysis/reconstructions.py
+++ b/sapphire/analysis/reconstructions.py
@@ -1,5 +1,4 @@
 from itertools import izip_longest
-from datetime import date
 
 from numpy import isnan, nan, histogram, linspace, percentile, std
 from scipy.optimize import curve_fit

--- a/sapphire/api.py
+++ b/sapphire/api.py
@@ -31,10 +31,11 @@ import warnings
 from os import path
 from urllib2 import urlopen, HTTPError, URLError
 from StringIO import StringIO
-from bisect import bisect_right
 
 from lazy import lazy
 from numpy import genfromtxt, atleast_1d
+
+from .utils import get_active_index
 
 logger = logging.getLogger('api')
 
@@ -153,20 +154,6 @@ class API(object):
         except URLError:
             return False
         return True
-
-    @staticmethod
-    def get_active_index(timestamps, timestamp):
-        """Get the index where the timestamp fits.
-
-        :param timestamps: list of timestamps.
-        :param timestamp: timestamp for which to find the position.
-        :return: index into the timestamps list.
-
-        """
-        idx = bisect_right(timestamps, timestamp, lo=0)
-        if idx == 0:
-            idx = 1
-        return idx - 1
 
 
 class Network(API):
@@ -689,7 +676,7 @@ class Station(API):
 
         """
         voltages = self.voltages
-        idx = self.get_active_index(voltages['timestamp'], timestamp)
+        idx = get_active_index(voltages['timestamp'], timestamp)
         voltage = [voltages[idx]['voltage%d' % i] for i in range(1, 5)]
         return voltage
 
@@ -712,7 +699,7 @@ class Station(API):
 
         """
         currents = self.currents
-        idx = self.get_active_index(currents['timestamp'], timestamp)
+        idx = get_active_index(currents['timestamp'], timestamp)
         current = [currents[idx]['current%d' % i] for i in range(1, 5)]
         return current
 
@@ -735,7 +722,7 @@ class Station(API):
 
         """
         locations = self.gps_locations
-        idx = self.get_active_index(locations['timestamp'], timestamp)
+        idx = get_active_index(locations['timestamp'], timestamp)
         location = {'latitude': locations[idx]['latitude'],
                     'longitude': locations[idx]['longitude'],
                     'altitude': locations[idx]['altitude']}
@@ -761,7 +748,7 @@ class Station(API):
 
         """
         detector_timing_offsets = self.detector_timing_offsets
-        idx = self.get_active_index(detector_timing_offsets['timestamp'],
+        idx = get_active_index(detector_timing_offsets['timestamp'],
                                     timestamp)
         detector_timing_offset = [detector_timing_offsets[idx]['offset%d' % i]
                                   for i in range(1, 5)]

--- a/sapphire/api.py
+++ b/sapphire/api.py
@@ -90,6 +90,7 @@ class API(object):
         'voltage': 'voltage/{station_number}/',
         'current': 'current/{station_number}/',
         'gps': 'gps/{station_number}/',
+        'layout': 'layout/{station_number}/',
         'detector_timing_offsets': 'detector_timing_offsets/{station_number}/'}
 
     @classmethod
@@ -729,6 +730,34 @@ class Station(API):
         return location
 
     @lazy
+    def station_layouts(self):
+        """Get the station layout data
+
+        :return: array of timestamps and values.
+
+        """
+        columns = ('timestamp',
+                   'radius1', 'alpha1', 'beta1', 'height1',
+                   'radius2', 'alpha2', 'beta2', 'height2',
+                   'radius3', 'alpha3', 'beta3', 'height3',
+                   'radius4', 'alpha4', 'beta4', 'height4')
+
+        base = self.src_urls['layout']
+        path = base.format(station_number=self.station)
+        return self._get_csv(path, names=columns)
+
+    def station_layout(self, timestamp):
+        """Get station layout data for specific timestamp
+
+        :param timestamp: timestamp for which the value is valid.
+        :return: list of values for given timestamp.
+
+        """
+        station_layouts = self.station_layouts
+        idx = get_active_index(station_layouts['timestamp'], timestamp)
+        return station_layouts[idx]
+
+    @lazy
     def detector_timing_offsets(self):
         """Get the detector timing offsets data
 
@@ -749,7 +778,7 @@ class Station(API):
         """
         detector_timing_offsets = self.detector_timing_offsets
         idx = get_active_index(detector_timing_offsets['timestamp'],
-                                    timestamp)
+                               timestamp)
         detector_timing_offset = [detector_timing_offsets[idx]['offset%d' % i]
                                   for i in range(1, 5)]
         return detector_timing_offset

--- a/sapphire/api.py
+++ b/sapphire/api.py
@@ -719,7 +719,7 @@ class Station(API):
         """Get GPS location for specific timestamp
 
         :param timestamp: timestamp for which the value is valid.
-        :return: list of values for given timestamp.
+        :return: dictionary with the values for given timestamp.
 
         """
         locations = self.gps_locations
@@ -737,10 +737,10 @@ class Station(API):
 
         """
         columns = ('timestamp',
-                   'radius1', 'alpha1', 'beta1', 'height1',
-                   'radius2', 'alpha2', 'beta2', 'height2',
-                   'radius3', 'alpha3', 'beta3', 'height3',
-                   'radius4', 'alpha4', 'beta4', 'height4')
+                   'radius1', 'alpha1', 'height1', 'beta1',
+                   'radius2', 'alpha2', 'height2', 'beta2',
+                   'radius3', 'alpha3', 'height3', 'beta3',
+                   'radius4', 'alpha4', 'height4', 'beta4')
 
         base = self.src_urls['layout']
         path = base.format(station_number=self.station)
@@ -750,12 +750,15 @@ class Station(API):
         """Get station layout data for specific timestamp
 
         :param timestamp: timestamp for which the value is valid.
-        :return: list of values for given timestamp.
+        :return: list of coordinates for given timestamp.
 
         """
         station_layouts = self.station_layouts
         idx = get_active_index(station_layouts['timestamp'], timestamp)
-        return station_layouts[idx]
+        station_layout = [[station_layouts[idx]['%s%d' % (c, i)]
+                           for c in ('radius', 'alpha', 'height', 'beta')]
+                          for i in range(1, 5)]
+        return station_layout
 
     @lazy
     def detector_timing_offsets(self):

--- a/sapphire/api.py
+++ b/sapphire/api.py
@@ -117,8 +117,10 @@ class API(object):
 
         """
         csv_data = cls._retrieve_url(urlpath, base=SRC_BASE)
-        data = genfromtxt(StringIO(csv_data), delimiter='\t', dtype=None,
-                          names=names)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            data = genfromtxt(StringIO(csv_data), delimiter='\t', dtype=None,
+                              names=names)
 
         return atleast_1d(data)
 

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -124,7 +124,7 @@ class Detector(object):
         # detector frame
         dx = size[0] / 2
         dy = size[1] / 2
-        corners = [(dx, -dy), (dx, dy), (-dx, dy), (-dx, -dy)]
+        corners = [(-dx, -dy), (dx, -dy), (dx, dy), (-dx, dy)]
 
         # station frame
         coso = cos(-o)

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -7,7 +7,7 @@
 """
 from __future__ import division
 
-from math import sqrt, pi, sin, cos, atan2, radians
+from math import sqrt, pi, sin, cos, atan2
 import warnings
 
 import numpy as np
@@ -146,8 +146,9 @@ class Station(object):
 
     _detectors = None
 
-    def __init__(self, cluster, station_id, position, angle=None, detectors=None,
-                 station_timestamps=[0], detector_timestamps=[0], number=None):
+    def __init__(self, cluster, station_id, position, angle=None,
+                 detectors=None, station_timestamps=[0],
+                 detector_timestamps=[0], number=None):
         """Initialize station
 
         :param cluster: cluster this station is a part of
@@ -762,7 +763,7 @@ class HiSPARCStations(RAlphaZBetaStations):
                                   'using GPS location (0, 0, 0).' % station,
                                   UserWarning)
                     llas = [(0., 0., 0.)]
-                    timestamps = [0]
+                    station_ts = [0]
                     n_detectors = 4
                 else:
                     raise KeyError('Could not get info for station %d.' %
@@ -776,7 +777,8 @@ class HiSPARCStations(RAlphaZBetaStations):
             if i == 0:
                 # Most recent location of first station as reference
                 self.lla = llas[-1]
-                transformation = geographic.FromWGS84ToENUTransformation(self.lla)
+                transformation = geographic.FromWGS84ToENUTransformation(
+                    self.lla)
 
             # Station locations in ENU
             enu = [transformation.transform(lla) for lla in llas]

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -28,12 +28,11 @@ class Detector(object):
 
         :param station: station instance this detector is part of.
         :param position: x,y,z position of the center of the detectors
-                         relative to the station center. z is optional.
+            relative to the station center. z is optional.
         :param orientation: orientation of the long side of the detector.
-                            Either the angle in radians, or 'UD' or 'LR'
-                            meaning an up-down or left-right orientation
-                            of the long side of the detector
-                            respectively.
+            Either the angle in radians, or 'UD' or 'LR' meaning an
+            up-down or left-right orientation of the long side of the
+            detector respectively.
 
         """
         self.station = station
@@ -365,7 +364,7 @@ class BaseCluster(object):
         """Add a station to the cluster
 
         :param position: x,y,z position of the station relative to
-                         cluster center. z is optional.
+            cluster center. z is optional.
         :param angle: angle of rotation of the station in radians
         :param detectors: list of tuples.  Each tuple consists of (dx, dy,
             dz, orientation) where dx, dy and dz are the positions of the

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -25,7 +25,7 @@ class Detector(object):
     def __init__(self, station, position, orientation='UD'):
         """Initialize detector
 
-        :param station: station instance this detector is part of
+        :param station: station instance this detector is part of.
         :param position: x,y,z position of the center of the detectors
                          relative to the station center. z is optional.
         :param orientation: orientation of the long side of the detector.
@@ -480,16 +480,18 @@ class RAlphaBetaStations(BaseCluster):
     def _add_station(self, position, detectors, number=None):
         """Add a station to the cluster
 
-        :param x,y,z: position of the station relative to cluster center
-        :param detectors: list of tuples. Each tuple consists of (r, alpha,
-            z, beta) these define the position of the detector relative to
-            the GPS and the orientation of the detector. r is the
-            distance between the center of the scintillator and the GPS
-            in meters in the x,y-plane. alpha is the clock-wise turning
-            angle between North and the detector relative to the GPS in
-            degrees. z is the height of the detector relative to the
-            GPS. beta is the clock-wise turning angle between North and
-            the long side of the detector in degrees.
+        :param position: x,y,z coordinates of the station relative
+            to cluster center.
+        :param detectors: list of tuples. Each tuple consists of
+            r,alpha,z,beta coordinates, these define the position of the
+            detector relative to the GPS and the orientation of the
+            detector. r is the distance between the center of the
+            scintillator and the GPS in meters in the x,y-plane. alpha
+            is the clock-wise turning angle between North and the
+            detector relative to the GPS in degrees. z is the height of
+            the detector relative to the GPS. beta is the clock-wise
+            turning angle between North and the long side of the
+            detector in degrees.
         :param number: optional unique identifier for a station this can
             later be used to find a specific station and makes it easier
             to link to a real station. If not given it will be equal to

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -546,9 +546,13 @@ class BaseCluster(object):
         return x0, y0, z0
 
 
-class RAlphaZBetaStations(BaseCluster):
+class CompassStations(BaseCluster):
 
-    """Add detectors to stations using r,alpha,z,beta coordinates
+    """Add detectors to stations using compass coordinates
+
+    Compass coordinates consist of r, alpha, z, beta. These define
+    the location and orientation of detectors. For more information
+    see `Coordinate systems and units in HiSPARC`.
 
     This is meant for data from the Publicdb Database API, which
     uses that coordinate system.
@@ -585,17 +589,15 @@ class RAlphaZBetaStations(BaseCluster):
 
         Example::
 
-            >>> cluster = RAlphaZBetaStations()
+            >>> cluster = CompassStations()
             >>> cluster._add_station((0, 0, 0), [(7, 0, 1, 0), (7, 90, 0, 0)],
             ...                      number=104)
 
         """
-        detectors = [((np.sin(np.radians(alpha)) * r,
-                       np.cos(np.radians(alpha)) * r,
-                       z),
-                      np.radians(beta)) for r, alpha, z, beta in detectors]
+        detectors = [(axes.compass_to_cartesian(r, alpha, z), np.radians(beta))
+                     for r, alpha, z, beta in detectors]
 
-        super(RAlphaZBetaStations, self)._add_station(
+        super(CompassStations, self)._add_station(
             position, None, detectors, station_timestamps, detector_timestamps,
             number)
 
@@ -764,7 +766,7 @@ class ScienceParkCluster(BaseCluster):
             self._add_station(enu, alpha, detectors, station)
 
 
-class HiSPARCStations(RAlphaZBetaStations):
+class HiSPARCStations(CompassStations):
 
     """A cluster containing any real station from the HiSPARC network
 

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -593,6 +593,17 @@ class SingleStation(BaseCluster):
         self._add_station((0, 0, 0), 0)
 
 
+class SingleDetectorStation(BaseCluster):
+    """Define a cluster containing a single 1-detector station"""
+
+    def __init__(self):
+        super(SingleDetectorStation, self).__init__()
+
+        detectors = [((0, 0, 0), 'UD')]
+
+        self._add_station((0, 0, 0), 0, detectors)
+
+
 class SingleTwoDetectorStation(BaseCluster):
     """Define a cluster containing a single 2 detector station"""
 

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -241,6 +241,11 @@ class Station(object):
         else:
             return sum(d.get_area() for d in self._detectors)
 
+    def get_xy_coordinates(self):
+        """Same as get_coordinates but without the z and alpha"""
+        x, y, _, _ = self.get_coordinates()
+        return x, y
+
     def get_xyalpha_coordinates(self):
         """Same as get_coordinates but without the z"""
         x, y, _, alpha = self.get_coordinates()
@@ -401,6 +406,10 @@ class BaseCluster(object):
         for station in self._stations:
             if number == station.number:
                 return station
+
+    def get_xy_coordinates(self):
+        """Same as get_coordinates but without the z and alpha"""
+        return self.x, self.y
 
     def get_xyalpha_coordinates(self):
         """Like get_coordinates, but without z"""

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -820,7 +820,7 @@ class HiSPARCStations(RAlphaZBetaStations):
             self._add_station(enu, razbs, station_ts, detector_ts, station)
 
         if len(missing_gps):
-            warnings.warn('Could not GPS location for stations: %s. '
+            warnings.warn('Could not get GPS location for stations: %s. '
                           'Using (0, 0, 0) instead.' % str(missing_gps),
                           UserWarning)
         if len(missing_detectors):

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -807,7 +807,7 @@ class HiSPARCStations(RAlphaZBetaStations):
             self._add_station(enu, razbs, station_ts, detector_ts, station)
 
         if len(missing_gps):
-            warnings.warn('Could not GPS location for stations: %s.'
+            warnings.warn('Could not GPS location for stations: %s. '
                           'Using (0, 0, 0) instead.' % str(missing_gps),
                           UserWarning)
         if len(missing_detectors):

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -135,7 +135,7 @@ class Station(object):
 
     _detectors = None
 
-    def __init__(self, cluster, station_id, position, angle=0, detectors=None,
+    def __init__(self, cluster, station_id, position, angle=None, detectors=None,
                  station_timestamps=[0], detector_timestamps=[0], number=None):
         """Initialize station
 
@@ -161,10 +161,12 @@ class Station(object):
         self.x = position[0]
         self.y = position[1]
         self.z = position[2] if len(position) == 3 else [0.] * len(self.x)
-        self.angle = angle
+        if angle is None:
+            self.angle = [0.] * len(self.x)
+        else:
+            self.angle = angle
         self.number = number if number else station_id
         self.timestamps = station_timestamps
-        print detectors
 
         if detectors is None:
             # detector positions for a standard station
@@ -184,7 +186,7 @@ class Station(object):
         for detector in self.detectors:
             detector._update_timestamp(timestamp)
 
-    def _add_detector(self, position, orientation):
+    def _add_detector(self, position, orientation, detector_timestamps):
         """Add detector to station
 
         :param position: x,y,z positions of the center of the detectors
@@ -196,7 +198,8 @@ class Station(object):
         """
         if self._detectors is None:
             self._detectors = []
-        self._detectors.append(Detector(self, position, orientation))
+        self._detectors.append(Detector(self, position, orientation,
+                                        detector_timestamps))
 
     @property
     def detectors(self):
@@ -519,14 +522,13 @@ class RAlphaZBetaStations(BaseCluster):
             ...                      number=104)
 
         """
-        print detectors
         detectors = [((np.sin(np.radians(alpha)) * r,
                        np.cos(np.radians(alpha)) * r,
                        z),
                       np.radians(beta)) for r, alpha, z, beta in detectors]
 
         super(RAlphaZBetaStations, self)._add_station(
-            position, 0, detectors, station_timestamps, detector_timestamps,
+            position, None, detectors, station_timestamps, detector_timestamps,
             number)
 
 

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -61,7 +61,11 @@ class Detector(object):
         self.index = -1
 
     def _update_timestamp(self, timestamp):
-        # do stuff
+        """Get the position index valid for the given timestamp
+
+        :param timestamp: timestamp in seconds.
+
+        """
         self.index = get_active_index(self.timestamps, timestamp)
 
     @property
@@ -205,7 +209,11 @@ class Station(object):
         self.index = -1
 
     def _update_timestamp(self, timestamp):
-        # do stuff
+        """Get the position index valid for the given timestamp
+
+        :param timestamp: timestamp in seconds.
+
+        """
         self.index = get_active_index(self.timestamps, timestamp)
         for detector in self.detectors:
             detector._update_timestamp(timestamp)
@@ -355,6 +363,11 @@ class BaseCluster(object):
         self._timestamp = 2147483647
 
     def set_timestamp(self, timestamp):
+        """Set the timestamp to set the active station and detector locations
+
+        :param timestamp: timestamp in seconds.
+
+        """
         self._timestamp = timestamp
         for station in self.stations:
             station._update_timestamp(self._timestamp)

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -66,7 +66,18 @@ class Detector(object):
         :param timestamp: timestamp in seconds.
 
         """
-        self.index = get_active_index(self.timestamps, timestamp)
+        # Most often the timestamp will be later then the previous,
+        # and often less than the next.
+        ci = self.index
+        if self.timestamps[ci] <= timestamp:
+            try:
+                if timestamp < self.timestamps[ci + 1]:
+                    return
+            except IndexError:
+                pass
+            self.index = get_active_index(self.timestamps[ci:], timestamp) + ci
+        else:
+            self.index = get_active_index(self.timestamps, timestamp)
 
     @property
     def detector_size(self):
@@ -214,9 +225,20 @@ class Station(object):
         :param timestamp: timestamp in seconds.
 
         """
-        self.index = get_active_index(self.timestamps, timestamp)
         for detector in self.detectors:
             detector._update_timestamp(timestamp)
+        # Most often the timestamp will be later then the previous,
+        # and often less than the next.
+        ci = self.index
+        if self.timestamps[ci] <= timestamp:
+            try:
+                if timestamp < self.timestamps[ci + 1]:
+                    return
+            except IndexError:
+                pass
+            self.index = get_active_index(self.timestamps[ci:], timestamp) + ci
+        else:
+            self.index = get_active_index(self.timestamps, timestamp)
 
     def _add_detector(self, position, orientation, detector_timestamps):
         """Add detector to station

--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -36,9 +36,9 @@ class Detector(object):
 
         """
         self.station = station
-        self.x = position[0]
-        self.y = position[1]
-        self.z = position[2] if len(position) == 3 else 0.
+        self.x = [position[0]]
+        self.y = [position[1]]
+        self.z = [position[2] if len(position) == 3 else 0.]
         if orientation == 'UD':
             self.orientation = 0
         elif orientation == 'LR':
@@ -68,9 +68,9 @@ class Detector(object):
         sina = sin(alpha)
         cosa = cos(alpha)
 
-        x = X + (self.x * cosa - self.y * sina)
-        y = Y + (self.x * sina + self.y * cosa)
-        z = Z + self.z
+        x = X + (self.x[self.index] * cosa - self.y[self.index] * sina)
+        y = Y + (self.x[self.index] * sina + self.y[self.index] * cosa)
+        z = Z + self.z[self.index]
 
         return x, y, z
 
@@ -156,10 +156,10 @@ class Station(object):
         """
         self.cluster = cluster
         self.station_id = station_id
-        self.x = position[0]
-        self.y = position[1]
-        self.z = position[2] if len(position) == 3 else 0.
-        self.angle = angle
+        self.x = [position[0]]
+        self.y = [position[1]]
+        self.z = [position[2] if len(position) == 3 else 0.]
+        self.angle = [angle]
         self.number = number if number else station_id
 
         if detectors is None:
@@ -227,10 +227,10 @@ class Station(object):
         sina = sin(alpha)
         cosa = cos(alpha)
 
-        x = X + (self.x * cosa - self.y * sina)
-        y = Y + (self.x * sina + self.y * cosa)
-        z = Z + self.z
-        alpha = alpha + self.angle
+        x = X + (self.x[self.index] * cosa - self.y[self.index] * sina)
+        y = Y + (self.x[self.index] * sina + self.y[self.index] * cosa)
+        z = Z + self.z[self.index]
+        alpha = alpha + self.angle[self.index]
 
         return x, y, z, alpha
 

--- a/sapphire/tests/analysis/test_direction_reconstruction.py
+++ b/sapphire/tests/analysis/test_direction_reconstruction.py
@@ -1,7 +1,7 @@
 import unittest
 import warnings
 
-from mock import Mock, sentinel
+from mock import sentinel
 from numpy import isnan, pi, sqrt, arcsin, arctan
 
 from sapphire.analysis import direction_reconstruction

--- a/sapphire/tests/analysis/test_direction_reconstruction.py
+++ b/sapphire/tests/analysis/test_direction_reconstruction.py
@@ -5,7 +5,6 @@ from mock import sentinel, Mock
 from numpy import isnan, pi, sqrt, arcsin, arctan
 
 from sapphire.analysis import direction_reconstruction
-from sapphire.clusters import SingleStation
 
 
 class EventDirectionReconstructionTest(unittest.TestCase):

--- a/sapphire/tests/analysis/test_direction_reconstruction.py
+++ b/sapphire/tests/analysis/test_direction_reconstruction.py
@@ -1,28 +1,45 @@
 import unittest
 import warnings
 
-from mock import sentinel
+from mock import sentinel, Mock
 from numpy import isnan, pi, sqrt, arcsin, arctan
 
 from sapphire.analysis import direction_reconstruction
+from sapphire.clusters import SingleStation
 
 
 class EventDirectionReconstructionTest(unittest.TestCase):
 
     def test_init(self):
-        self.dirrec = direction_reconstruction.EventDirectionReconstruction(sentinel.station)
-        self.assertEqual(self.dirrec.direct, direction_reconstruction.DirectAlgorithmCartesian3D)
-        self.assertEqual(self.dirrec.fit, direction_reconstruction.RegressionAlgorithm3D)
-        self.assertEqual(self.dirrec.station, sentinel.station)
+        dirrec = direction_reconstruction.EventDirectionReconstruction(sentinel.station)
+        self.assertEqual(dirrec.direct, direction_reconstruction.DirectAlgorithmCartesian3D)
+        self.assertEqual(dirrec.fit, direction_reconstruction.RegressionAlgorithm3D)
+        self.assertEqual(dirrec.station, sentinel.station)
 
+    def test_set_cluster_timestamp(self):
+        station = Mock()
+        dirrec = direction_reconstruction.EventDirectionReconstruction(station)
+        theta, phi, ids = dirrec.reconstruct_event({'timestamp': sentinel.timestamp}, detector_ids=[])
+        station.cluster.set_timestamp.assert_called_with(sentinel.timestamp)
+        self.assertTrue(isnan(theta))
+        self.assertTrue(isnan(phi))
 
 class CoincidenceDirectionReconstructionTest(unittest.TestCase):
 
     def test_init(self):
-        self.dirrec = direction_reconstruction.CoincidenceDirectionReconstruction(sentinel.cluster)
-        self.assertEqual(self.dirrec.direct, direction_reconstruction.DirectAlgorithmCartesian3D)
-        self.assertEqual(self.dirrec.fit, direction_reconstruction.RegressionAlgorithm3D)
-        self.assertEqual(self.dirrec.cluster, sentinel.cluster)
+        dirrec = direction_reconstruction.CoincidenceDirectionReconstruction(sentinel.cluster)
+        self.assertEqual(dirrec.direct, direction_reconstruction.DirectAlgorithmCartesian3D)
+        self.assertEqual(dirrec.fit, direction_reconstruction.RegressionAlgorithm3D)
+        self.assertEqual(dirrec.cluster, sentinel.cluster)
+
+    def test_set_cluster_timestamp(self):
+        cluster = Mock()
+        dirrec = direction_reconstruction.CoincidenceDirectionReconstruction(cluster)
+        coincidence = [[sentinel.station_number, {'timestamp': 1}], [0, 0], [0, 0]]
+        theta, phi, nums = dirrec.reconstruct_coincidence(coincidence, station_numbers=[])
+        cluster.set_timestamp.assert_called_with(1)
+        self.assertTrue(isnan(theta))
+        self.assertTrue(isnan(phi))
 
 
 class BaseAlgorithm(object):

--- a/sapphire/tests/analysis/test_direction_reconstruction.py
+++ b/sapphire/tests/analysis/test_direction_reconstruction.py
@@ -24,6 +24,7 @@ class EventDirectionReconstructionTest(unittest.TestCase):
         self.assertTrue(isnan(theta))
         self.assertTrue(isnan(phi))
 
+
 class CoincidenceDirectionReconstructionTest(unittest.TestCase):
 
     def test_init(self):

--- a/sapphire/tests/analysis/test_direction_reconstruction.py
+++ b/sapphire/tests/analysis/test_direction_reconstruction.py
@@ -1,9 +1,28 @@
 import unittest
 import warnings
 
+from mock import Mock, sentinel
 from numpy import isnan, pi, sqrt, arcsin, arctan
 
 from sapphire.analysis import direction_reconstruction
+
+
+class EventDirectionReconstructionTest(unittest.TestCase):
+
+    def test_init(self):
+        self.dirrec = direction_reconstruction.EventDirectionReconstruction(sentinel.station)
+        self.assertEqual(self.dirrec.direct, direction_reconstruction.DirectAlgorithmCartesian3D)
+        self.assertEqual(self.dirrec.fit, direction_reconstruction.RegressionAlgorithm3D)
+        self.assertEqual(self.dirrec.station, sentinel.station)
+
+
+class CoincidenceDirectionReconstructionTest(unittest.TestCase):
+
+    def test_init(self):
+        self.dirrec = direction_reconstruction.CoincidenceDirectionReconstruction(sentinel.cluster)
+        self.assertEqual(self.dirrec.direct, direction_reconstruction.DirectAlgorithmCartesian3D)
+        self.assertEqual(self.dirrec.fit, direction_reconstruction.RegressionAlgorithm3D)
+        self.assertEqual(self.dirrec.cluster, sentinel.cluster)
 
 
 class BaseAlgorithm(object):
@@ -11,6 +30,7 @@ class BaseAlgorithm(object):
     """Use this class to check the different algorithms
 
     They should give similar results and errors in some cases.
+    Theses tests use three detections at same height.
 
     """
 

--- a/sapphire/tests/analysis/test_event_utils.py
+++ b/sapphire/tests/analysis/test_event_utils.py
@@ -133,7 +133,7 @@ class RelativeDetectorArrivalTimesTests(unittest.TestCase):
 
     @patch.object(event_utils, 'detector_arrival_times')
     @patch.object(event_utils, 'get_detector_ids')
-    def test_relative_detector_arrival_times(self, mock_detector_ids, mock_detector_arrival_times):
+    def test_nan_relative_detector_arrival_times(self, mock_detector_ids, mock_detector_arrival_times):
         mock_detector_ids.return_value = range(4)
         mock_detector_arrival_times.return_value = [7.5, 5., 5., nan]
         event_dict = {'t_trigger': 10, 'ext_timestamp': 1000}

--- a/sapphire/tests/analysis/test_event_utils.py
+++ b/sapphire/tests/analysis/test_event_utils.py
@@ -1,0 +1,63 @@
+import unittest
+
+from mock import MagicMock
+from numpy import isnan
+
+from sapphire.analysis import event_utils
+
+
+class DetectorDensityTests(unittest.TestCase):
+
+    def setUp(self):
+        self.event = MagicMock()
+        self.station = MagicMock()
+
+    def test_detector_density(self):
+        self.event.__getitem__.side_effect = lambda name: 2
+        self.assertEqual(event_utils.detector_density(self.event, 0), 4)
+        self.event.__getitem__.assert_called_with('n1')
+
+    def test_no_good_detector_density(self):
+        self.event.__getitem__.side_effect = lambda name: -999
+        self.assertTrue(isnan(event_utils.detector_density(self.event, 0)))
+        self.event.__getitem__.assert_called_with('n1')
+
+
+class DetectorArrivalTimeTests(unittest.TestCase):
+
+    def setUp(self):
+        self.event = MagicMock()
+        self.offsets = [1, 2, 3, 4]
+
+    def test_detector_arrival_time(self):
+        self.event.__getitem__.side_effect = lambda name: 2.5
+        self.assertEqual(event_utils.detector_arrival_time(self.event, 0), 2.5)
+        self.event.__getitem__.assert_called_with('t1')
+        self.assertEqual(event_utils.detector_arrival_time(self.event, 0, self.offsets), 1.5)
+        self.event.__getitem__.assert_called_with('t1')
+        self.assertEqual(event_utils.detector_arrival_time(self.event, 1, self.offsets), 0.5)
+        self.event.__getitem__.assert_called_with('t2')
+
+    def test_no_good_detector_arrival_time(self):
+        self.event.__getitem__.side_effect = lambda name: -999
+        self.assertTrue(isnan(event_utils.detector_arrival_time(self.event, 0)))
+        self.event.__getitem__.assert_called_with('t1')
+        self.assertTrue(isnan(event_utils.detector_arrival_time(self.event, 0, self.offsets)))
+        self.event.__getitem__.assert_called_with('t1')
+
+
+class GetDetectorIdsTests(unittest.TestCase):
+
+    def test_get_detector_ids(self):
+        self.assertEqual(event_utils.get_detector_ids(), range(4))
+        station = MagicMock()
+        station.detectors.__len__.return_value = 2
+        self.assertEqual(event_utils.get_detector_ids(station=station), range(2))
+        event = MagicMock()
+        event.__getitem__.side_effect = lambda name: [10, 100, 40, -1]
+        self.assertEqual(event_utils.get_detector_ids(event=event), range(3))
+        self.assertEqual(event_utils.get_detector_ids(station=station, event=event), range(2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sapphire/tests/analysis/test_event_utils.py
+++ b/sapphire/tests/analysis/test_event_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from mock import MagicMock, patch, sentinel
 from numpy import isnan, nan
@@ -30,12 +31,16 @@ class DetectorDensitiesTests(unittest.TestCase):
     def test_detector_densities(self, mock_detector_ids, mock_detector_density):
         mock_detector_ids.return_value = range(4)
         mock_detector_density.return_value = sentinel.density
-        self.assertEqual(event_utils.detector_densities(sentinel.event, range(4)), [sentinel.density] * 4)
-        self.assertEqual(event_utils.detector_densities(sentinel.event, range(2)), [sentinel.density] * 2)
+        self.assertEqual(event_utils.detector_densities(sentinel.event, range(4)),
+                         [sentinel.density] * 4)
+        self.assertEqual(event_utils.detector_densities(sentinel.event, range(2)),
+                         [sentinel.density] * 2)
         self.assertEqual(mock_detector_ids.call_count, 0)
-        self.assertEqual(event_utils.detector_densities(sentinel.event), [sentinel.density] * 4)
+        self.assertEqual(event_utils.detector_densities(sentinel.event),
+                         [sentinel.density] * 4)
         mock_detector_ids.assert_called_once_with(None, sentinel.event)
-        self.assertEqual(event_utils.detector_densities(sentinel.event, station=sentinel.station), [sentinel.density] * 4)
+        self.assertEqual(event_utils.detector_densities(sentinel.event, station=sentinel.station),
+                         [sentinel.density] * 4)
         mock_detector_ids.assert_called_with(sentinel.station, sentinel.event)
 
 
@@ -54,6 +59,59 @@ class DetectorDensityTests(unittest.TestCase):
         self.event.__getitem__.side_effect = lambda name: -999
         self.assertTrue(isnan(event_utils.detector_density(self.event, 0)))
         self.event.__getitem__.assert_called_with('n1')
+
+
+class StationArrivalTimeTests(unittest.TestCase):
+
+    @patch.object(event_utils, 'detector_arrival_times')
+    @patch.object(event_utils, 'get_detector_ids')
+    def test_station_density(self, mock_detector_ids, mock_detector_arrival_times):
+        mock_detector_ids.return_value = range(4)
+        mock_detector_arrival_times.return_value = [7.5, 5., 2.5, 5.]
+        event_dict = {'t_trigger': 10, 'ext_timestamp': 1000}
+        event = MagicMock()
+        event.__getitem__.side_effect = lambda name: event_dict[name]
+        self.assertEqual(event_utils.station_arrival_time(event, 500, range(4), sentinel.offsets, sentinel.station),
+                         1000 - 500 - 10 + 2.5)
+        self.assertEqual(mock_detector_ids.call_count, 0)
+        self.assertEqual(event_utils.station_arrival_time(event, 500, None, sentinel.offsets),
+                         1000 - 500 - 10 + 2.5)
+        mock_detector_ids.assert_called_once_with(None, event)
+        self.assertEqual(event_utils.station_arrival_time(event, 500, None, sentinel.offsets, sentinel.station),
+                         1000 - 500 - 10 + 2.5)
+        mock_detector_ids.assert_called_with(sentinel.station, event)
+        mock_detector_arrival_times.return_value = [7.5, 5., nan, 5.]
+        self.assertEqual(event_utils.station_arrival_time(event, 500, None, sentinel.offsets, sentinel.station),
+                         1000 - 500 - 10 + 5)
+        event_dict['t_trigger'] = -999
+        self.assertTrue(isnan(event_utils.station_arrival_time(event, 500, None, sentinel.offsets, sentinel.station)))
+        event_dict['t_trigger'] = nan
+        self.assertTrue(isnan(event_utils.station_arrival_time(event, 500, None, sentinel.offsets, sentinel.station)))
+        mock_detector_arrival_times.return_value = [nan, nan, nan, nan]
+        with warnings.catch_warnings(record=True) as warned:
+            self.assertTrue(isnan(event_utils.station_arrival_time(event, 500, None, sentinel.offsets, sentinel.station)))
+        self.assertEqual(len(warned), 1)
+
+
+class DetectorArrivalTimesTests(unittest.TestCase):
+
+    @patch.object(event_utils, 'detector_arrival_time')
+    @patch.object(event_utils, 'get_detector_ids')
+    def test_detector_densities(self, mock_detector_ids, mock_detector_arrival_time):
+        mock_detector_ids.return_value = range(4)
+
+        mock_detector_arrival_time.return_value = sentinel.time
+        self.assertEqual(event_utils.detector_arrival_times(sentinel.event, range(4)),
+                         [sentinel.time] * 4)
+        self.assertEqual(event_utils.detector_arrival_times(sentinel.event, range(2)),
+                         [sentinel.time] * 2)
+        self.assertEqual(mock_detector_ids.call_count, 0)
+        self.assertEqual(event_utils.detector_arrival_times(sentinel.event),
+                         [sentinel.time] * 4)
+        mock_detector_ids.assert_called_once_with(None, sentinel.event)
+        self.assertEqual(event_utils.detector_arrival_times(sentinel.event, station=sentinel.station),
+                         [sentinel.time] * 4)
+        mock_detector_ids.assert_called_with(sentinel.station, sentinel.event)
 
 
 class DetectorArrivalTimeTests(unittest.TestCase):

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -33,15 +33,9 @@ class APITests(unittest.TestCase):
 class NetworkTests(unittest.TestCase):
     def setUp(self):
         self.network = api.Network()
+        self.keys = ['name', 'number']
 
-    def test_keys(self):
-        keys = ['name', 'number']
-        self.assertEqual(self.network.countries()[0].keys(), keys)
-        self.assertEqual(self.network.clusters()[0].keys(), keys)
-        self.assertEqual(self.network.subclusters()[0].keys(), keys)
-        self.assertEqual(self.network.stations()[0].keys(), keys)
-        self.assertEqual(self.network.stations_with_data(2004, 1, 9)[0].keys(), keys)
-        self.assertEqual(self.network.stations_with_weather(2004, 10, 9)[0].keys(), keys)
+    def test_nested_network(self):
         nested_network = self.network.nested_network()
         self.assertEqual(nested_network[0].keys(), ['clusters', 'name', 'number'])
         self.assertEqual(nested_network[0]['clusters'][0].keys(),
@@ -52,19 +46,26 @@ class NetworkTests(unittest.TestCase):
     def test_countries(self):
         self.network.countries()
         self.assertEqual(self.network._all_countries, self.network.countries())
+        self.assertEqual(self.network.countries()[0].keys(), self.keys)
 
     def test_clusters(self):
         self.network.clusters()
         self.assertEqual(self.network._all_clusters, self.network.clusters())
+        self.assertEqual(self.network.clusters()[0].keys(), self.keys)
         self.assertEqual(self.network.clusters(country=70000)[0]['number'], 70000)
+
+    def test_bad_clusters(self):
         bad_number = 1
         self.assertRaises(Exception, self.network.clusters, country=bad_number)
 
     def test_subcluster(self):
         self.network.subclusters()
         self.assertEqual(self.network._all_subclusters, self.network.subclusters())
+        self.assertEqual(self.network.subclusters()[0].keys(), self.keys)
         self.assertEqual(self.network.subclusters(country=70000)[0]['number'], 70000)
         self.assertEqual(self.network.subclusters(cluster=70000)[0]['number'], 70000)
+
+    def test_bad_subcluster(self):
         bad_number = 1
         self.assertRaises(Exception, self.network.subclusters, country=bad_number)
         self.assertRaises(Exception, self.network.subclusters, cluster=bad_number)
@@ -137,19 +138,24 @@ class NetworkTests(unittest.TestCase):
             self.assertRaises(Exception, self.network.station_numbers,
                               subcluster=bad_number, allow_stale=allow)
 
-    def test_bad_stations(self):
+    def test_stations(self):
         self.network.stations()
         self.assertEqual(self.network._all_stations, self.network.stations())
+        self.assertEqual(self.network.stations()[0].keys(), self.keys)
         self.assertEqual(self.network.stations(country=70000)[0]['number'], 70001)
         self.assertEqual(self.network.stations(cluster=70000)[0]['number'], 70001)
         self.assertEqual(self.network.stations(subcluster=70000)[0]['number'], 70001)
+
+    def test_bad_stations(self):
         bad_number = 1
         self.assertRaises(Exception, self.network.stations, country=bad_number)
         self.assertRaises(Exception, self.network.stations, cluster=bad_number)
         self.assertRaises(Exception, self.network.stations, subcluster=bad_number)
 
     def test_stations_with_data(self):
-        self.assertEqual(self.network.stations_with_data(2004, 1, 9)[0]['number'], 2)
+        stations_with_data = self.network.stations_with_data(2004, 1, 9)
+        self.assertEqual(stations_with_data[0].keys(), self.keys)
+        self.assertEqual(stations_with_data[0]['number'], 2)
         self.assertEqual(len(self.network.stations_with_data(2004, 1, 1)), 0)
         self.assertRaises(Exception, self.network.stations_with_data, year=2004, day=1)
         self.assertRaises(Exception, self.network.stations_with_data, month=1, day=1)
@@ -157,7 +163,9 @@ class NetworkTests(unittest.TestCase):
         self.assertRaises(Exception, self.network.stations_with_data, day=1)
 
     def test_stations_with_weather(self):
-        self.assertEqual(self.network.stations_with_weather(2004, 10, 9)[0]['number'], 3)
+        stations_with_weather = self.network.stations_with_weather(2004, 10, 9)
+        self.assertEqual(stations_with_weather[0].keys(), self.keys)
+        self.assertEqual(stations_with_weather[0]['number'], 3)
         self.assertEqual(len(self.network.stations_with_weather(2004, 1, 1)), 0)
         self.assertRaises(Exception, self.network.stations_with_weather, year=2004, day=1)
         self.assertRaises(Exception, self.network.stations_with_weather, month=1, day=1)

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -190,10 +190,10 @@ class StationTests(unittest.TestCase):
         self.assertRaises(Exception, api.Station, 501, allow_stale=False)
 
     @patch.object(api.Station, '_get_json')
-    def test_no_stale_station(self, mock_get_json):
+    def test_stale_station(self, mock_get_json):
         mock_get_json.side_effect = Exception('no interwebs!')
         with warnings.catch_warnings(record=True) as warned:
-            station = api.Station(501, allow_stale=True)
+            api.Station(501, allow_stale=True)
         self.assertEqual(len(warned), 1)
 
     def test_id_numbers(self):

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -247,15 +247,8 @@ class StationTests(unittest.TestCase):
         data = self.station.voltages
         self.assertEqual(data.dtype.names, names)
 
-    @patch.object(api.API, '_get_csv')
-    def test_laziness_voltages(self, mock_get_csv):
-        self.assertFalse(mock_get_csv.called)
-        data = self.station.voltages
-        self.assertTrue(mock_get_csv.called)
-        self.assertEqual(mock_get_csv.call_count, 1)
-        data2 = self.station.voltages
-        self.assertEqual(mock_get_csv.call_count, 1)
-        self.assertEqual(data, data2)
+    def test_laziness_voltages(self):
+        self.laziness_of_attribute('voltages')
 
     def test_voltage(self):
         data = self.station.voltage(1378771200)  # 2013-9-10
@@ -270,15 +263,8 @@ class StationTests(unittest.TestCase):
         self.assertEqual(data, [data2['voltage1'], data2['voltage2'],
                                 data2['voltage3'], data2['voltage4']])
 
-    @patch.object(api.API, '_get_csv')
-    def test_laziness_currents(self, mock_get_csv):
-        self.assertFalse(mock_get_csv.called)
-        data = self.station.currents
-        self.assertTrue(mock_get_csv.called)
-        self.assertEqual(mock_get_csv.call_count, 1)
-        data2 = self.station.currents
-        self.assertEqual(mock_get_csv.call_count, 1)
-        self.assertEqual(data, data2)
+    def test_laziness_currents(self):
+        self.laziness_of_attribute('currents')
 
     def test_currents(self):
         names = ('timestamp', 'current1', 'current2', 'current3', 'current4')
@@ -289,20 +275,13 @@ class StationTests(unittest.TestCase):
         data = self.station.current(1378771200)  # 2013-9-10
         self.assertEqual(data, [7.84, 7.94, 10.49, 10.88])
 
+    def test_laziness_gps_locations(self):
+        self.laziness_of_attribute('gps_locations')
+
     def test_gps_locations(self):
         names = ('timestamp', 'latitude', 'longitude', 'altitude')
         data = self.station.gps_locations
         self.assertEqual(data.dtype.names, names)
-
-    @patch.object(api.API, '_get_csv')
-    def test_laziness_gps_locations(self, mock_get_csv):
-        self.assertFalse(mock_get_csv.called)
-        data = self.station.gps_locations
-        self.assertTrue(mock_get_csv.called)
-        self.assertEqual(mock_get_csv.call_count, 1)
-        data2 = self.station.gps_locations
-        self.assertEqual(mock_get_csv.call_count, 1)
-        self.assertEqual(data, data2)
 
     def test_gps_location(self):
         keys = ['latitude', 'longitude', 'altitude']
@@ -310,20 +289,35 @@ class StationTests(unittest.TestCase):
         self.assertItemsEqual(data.keys(), keys)
         self.assertItemsEqual(data.values(), [52.3559286, 4.9511443, 54.97])
 
-    @patch.object(api.API, '_get_csv')
-    def test_laziness_detector_timing_offsets(self, mock_get_csv):
-        self.assertFalse(mock_get_csv.called)
-        data = self.station.detector_timing_offsets
-        self.assertTrue(mock_get_csv.called)
-        self.assertEqual(mock_get_csv.call_count, 1)
-        data2 = self.station.detector_timing_offsets
-        self.assertEqual(mock_get_csv.call_count, 1)
-        self.assertEqual(data, data2)
+    def test_laziness_station_layouts(self):
+        self.laziness_of_attribute('station_layouts')
+
+    def test_gps_locations(self):
+        names = ('timestamp', 'latitude', 'longitude', 'altitude')
+        data = self.station.gps_locations
+        self.assertEqual(data.dtype.names, names)
+
+    def test_laziness_detector_timing_offsets(self):
+        self.laziness_of_attribute('detector_timing_offsets')
 
     def test_detector_timing_offsets(self):
         names = ('timestamp', 'offset1', 'offset2', 'offset3', 'offset4')
         data = self.station.detector_timing_offsets
         self.assertEqual(data.dtype.names, names)
+
+    def test_detector_timing_offset(self):
+        offsets = self.station.detector_timing_offset(0)
+        self.assertEqual(len(offsets), 4)
+
+    def laziness_of_attribute(self, attribute):
+        with patch.object(api.API, '_get_csv') as mock_get_csv:
+            self.assertFalse(mock_get_csv.called)
+            data = self.station.__getattribute__(attribute)
+            self.assertTrue(mock_get_csv.called)
+            self.assertEqual(mock_get_csv.call_count, 1)
+            data2 = self.station.__getattribute__(attribute)
+            self.assertEqual(mock_get_csv.call_count, 1)
+            self.assertEqual(data, data2)
 
 
 if __name__ == '__main__':

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -292,10 +292,19 @@ class StationTests(unittest.TestCase):
     def test_laziness_station_layouts(self):
         self.laziness_of_attribute('station_layouts')
 
-    def test_gps_locations(self):
-        names = ('timestamp', 'latitude', 'longitude', 'altitude')
-        data = self.station.gps_locations
+    def test_station_layouts(self):
+        names = ('timestamp',
+                 'radius1', 'alpha1', 'height1', 'beta1',
+                 'radius2', 'alpha2', 'height2', 'beta2',
+                 'radius3', 'alpha3', 'height3', 'beta3',
+                 'radius4', 'alpha4', 'height4', 'beta4')
+        data = self.station.station_layouts
         self.assertEqual(data.dtype.names, names)
+
+    def test_station_layout(self):
+        data = self.station.station_layout(0)
+        self.assertEqual(len(data), 4)
+        self.assertEqual(len(data[0]), 4)
 
     def test_laziness_detector_timing_offsets(self):
         self.laziness_of_attribute('detector_timing_offsets')

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -213,6 +213,7 @@ class StationTests(unittest.TestCase):
 
     def test_event_trace(self):
         self.assertEqual(self.station.event_trace(1378771205, 571920029)[3][9], 268)
+        self.assertEqual(self.station.event_trace(1378771205, 571920029, raw=True)[3][9], 464)
 
     def test_event_time(self):
         names = ('hour', 'counts')

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -9,27 +9,6 @@ from sapphire import api
 STATION = 501
 
 
-class APITests(unittest.TestCase):
-    def setUp(self):
-        self.api = api.API()
-
-    def test_get_active_index(self):
-        """Test if the bisection returns the correct index
-
-        - If timestamp is before the first timestamp return index for
-          first item
-        - If timestamp is after last timestamp return index for last item
-        - If timestamp is in the range return index of rightmost value
-          equal or less than the timestamp
-
-        """
-        timestamps = [1., 2., 3., 4.]
-
-        for idx, ts in [(0, 0.), (0, 1.), (0, 1.5), (1, 2.), (1, 2.1), (3, 4.),
-                        (3, 5.)]:
-            self.assertEqual(self.api.get_active_index(timestamps, ts), idx)
-
-
 @unittest.skipUnless(api.API.check_connection(), "Internet connection required")
 class NetworkTests(unittest.TestCase):
     def setUp(self):

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -27,7 +27,7 @@ class DetectorTests(unittest.TestCase):
 
     def test__update_timestamp(self):
         self.assertEqual(self.detector_4d.index, -1)
-        for ts, index in [(-1, 0), (0, 0), (3, 0), (7, 1)]:
+        for ts, index in [(-1, 0), (0, 0), (3, 0), (7, 1), (8, 1)]:
             self.detector_4d._update_timestamp(ts)
             self.assertEqual(self.detector_4d.index, index)
 

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -65,12 +65,12 @@ class DetectorTests(unittest.TestCase):
     def test_LR_get_corners(self):
         self.mock_station.get_coordinates.return_value = (.25, 3, 0, 0)
         corners = self.detector_1.get_corners()
-        self.assertEqual(corners, [(.75, 2.75), (1.75, 2.75), (1.75, 3.25), (.75, 3.25)])
+        self.assertEqual(corners, [(.75, 3.25), (.75, 2.75), (1.75, 2.75), (1.75, 3.25)])
 
     def test_LR_get_corners_rotated(self):
         self.mock_station.get_coordinates.return_value = (0, 0, 0, pi / 2)
         corners = self.detector_1.get_corners()
-        expected_corners = [(.25, .5), (.25, 1.5), (-.25, 1.5), (-.25, .5)]
+        expected_corners = [(-.25, .5), (.25, .5), (.25, 1.5), (-.25, 1.5)]
         for (x, y), (expected_x, expected_y) in zip(corners, expected_corners):
             self.assertAlmostEqual(x, expected_x)
             self.assertAlmostEqual(y, expected_y)
@@ -78,7 +78,7 @@ class DetectorTests(unittest.TestCase):
     def test_UD_get_corners(self):
         self.mock_station.get_coordinates.return_value = (.25, 3, 0, 0)
         corners = self.detector_2.get_corners()
-        self.assertEqual(corners, [(-.5, 4.5), (-.5, 5.5), (-1, 5.5), (-1, 4.5)])
+        self.assertEqual(corners, [(-1, 4.5), (-.5, 4.5), (-.5, 5.5), (-1, 5.5)])
 
     def test_unknown_rotation_get_corners(self):
         self.mock_station.get_coordinates.return_value = (0, 0, 0, 0)

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -121,7 +121,7 @@ class StationTests(unittest.TestCase):
             self.mock_detector_instance = mock_detector.return_value
 
     def test_bad_arguments(self):
-        with patch('sapphire.clusters.Detector') as mock_detector:
+        with patch('sapphire.clusters.Detector'):
             self.assertRaises(Exception, clusters.Station,
                               cluster=self.cluster, station_id=1,
                               position=(0, 1, 2), station_timestamps=[1, 2])
@@ -304,7 +304,7 @@ class BaseClusterTests(unittest.TestCase):
                                             detector_list, [0], [0], number)
 
     def test_set_timestamp(self):
-        with patch('sapphire.clusters.Station') as mock_station:
+        with patch('sapphire.clusters.Station'):
             cluster = clusters.BaseCluster()
             cluster._add_station(sentinel.position)
             self.assertEqual(cluster._timestamp, 2147483647)

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -126,6 +126,12 @@ class StationTests(unittest.TestCase):
                               cluster=self.cluster, station_id=1,
                               position=(0, 1, 2), station_timestamps=[1, 2])
 
+    def test__update_timestamp(self):
+        self.assertEqual(self.station_4d.index, -1)
+        for ts, index in [(-1, 0), (0, 0), (3, 0), (7, 1), (8, 1)]:
+            self.station_4d._update_timestamp(ts)
+            self.assertEqual(self.station_4d.index, index)
+
     def test_4d_positions(self):
         self.cluster.get_coordinates.return_value = (0, 0, 0, 0)
         self.assertEqual(self.station_4d.get_coordinates(), (5, 5, 5, pi))

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -401,9 +401,9 @@ class BaseClusterTests(unittest.TestCase):
         self.assertAlmostEqual(y, 5 * sqrt(3) / 3)
 
 
-class RAlphaZBetaStationsTests(unittest.TestCase):
+class CompassStationsTests(unittest.TestCase):
     def test_cluster_stations(self):
-        cluster = clusters.RAlphaZBetaStations()
+        cluster = clusters.CompassStations()
         cluster._add_station((0, 0, 0), [(5, 270, 0, 0)])
         stations = cluster.stations
         self.assertEqual(len(stations), 1)

--- a/sapphire/tests/test_clusters_acceptance.py
+++ b/sapphire/tests/test_clusters_acceptance.py
@@ -14,7 +14,7 @@ class SimpleClusterTest(unittest.TestCase):
         a = sqrt(100 ** 2 - 50 ** 2)
         expected = [(0, 2 * a / 3, 0, 0), (0, 0, 0, 0),
                     (-50, -a / 3, 0, 2 * pi / 3), (50, -a / 3, 0, -2 * pi / 3)]
-        actual = [(station.x, station.y, station.z, station.angle)
+        actual = [(station.x[0], station.y[0], station.z[0], station.angle[0])
                   for station in self.cluster.stations]
 
         for actual_value, expected_value in zip(actual, expected):

--- a/sapphire/tests/test_utils.py
+++ b/sapphire/tests/test_utils.py
@@ -80,6 +80,25 @@ class InBaseTests(unittest.TestCase):
         self.assertEqual(utils.round_in_base(3, 4), 4)
 
 
+class ActiveIndexTests(unittest.TestCase):
+
+    def test_get_active_index(self):
+        """Test if the bisection returns the correct index
+
+        - If timestamp is before the first timestamp return index for
+          first item
+        - If timestamp is after last timestamp return index for last item
+        - If timestamp is in the range return index of rightmost value
+          equal or less than the timestamp
+
+        """
+        timestamps = [1., 2., 3., 4.]
+
+        for idx, ts in [(0, 0.), (0, 1.), (0, 1.5), (1, 2.), (1, 2.1), (3, 4.),
+                        (3, 5.)]:
+            self.assertEqual(utils.get_active_index(timestamps, ts), idx)
+
+
 class GaussTests(unittest.TestCase):
     """Test against explicit Gaussian"""
 

--- a/sapphire/tests/transformations/test_axes.py
+++ b/sapphire/tests/transformations/test_axes.py
@@ -8,39 +8,50 @@ from sapphire.transformations import axes
 class CoordinateSystemTests(unittest.TestCase):
 
     def setUp(self):
-        """Combinations of cartesian, spherical and cylindrical coordinates"""
+        """Test combinations of coordinates
 
+        Cartesian, spherical, cylindrical, and compass coordinates
+
+        """
         self.combinations = (
-            ((0, 0, 0), (0, 0, 0), (0, 0, 0)),
-            ((1, 0, 0), (1, pi / 2., 0), (1, 0, 0)),
-            ((0, 1, 0), (1, pi / 2., pi / 2.), (1, pi / 2., 0)),
-            ((0, -1, 0), (1, pi / 2., -pi / 2.), (1, -pi / 2., 0)),
-            ((1, 1, 1), (sqrt(3), arccos(1 / sqrt(3)), pi / 4.,), (sqrt(2), pi / 4., 1)),
-            ((0, 0, 1), (1, 0, 0), (0, 0, 1)))
+            ((0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0)),
+            ((1, 0, 0), (1, pi / 2., 0), (1, 0, 0), (1, 90, 0)),
+            ((0, 1, 0), (1, pi / 2., pi / 2.), (1, pi / 2., 0), (1, 0, 0)),
+            ((0, -1, 0), (1, pi / 2., -pi / 2.), (1, -pi / 2., 0), (1, 180, 0)),
+            ((1, 1, 1), (sqrt(3), arccos(1 / sqrt(3)), pi / 4.), (sqrt(2), pi / 4., 1), (sqrt(2), 45, 1)),
+            ((0, 0, 1), (1, 0, 0), (0, 0, 1), (0, 0, 1)))
 
     def test_cartesian_to_spherical(self):
-        for cartesian, spherical, _ in self.combinations:
+        for cartesian, spherical, _, _ in self.combinations:
             self.assertEqual(axes.cartesian_to_spherical(*cartesian), spherical)
 
     def test_cartesian_to_cylindrical(self):
-        for cartesian, _, cylindrical in self.combinations:
+        for cartesian, _, cylindrical, _ in self.combinations:
             self.assertEqual(axes.cartesian_to_cylindrical(*cartesian), cylindrical)
 
     def test_cartesian_to_polar(self):
-        for cartesian, _, cylindrical in self.combinations:
+        for cartesian, _, cylindrical, _ in self.combinations:
             self.assertEqual(axes.cartesian_to_polar(*cartesian[:2]), cylindrical[:2])
 
+    def test_cartesian_to_compass(self):
+        for cartesian, _, _, compass in self.combinations:
+            self.assertEqual(axes.cartesian_to_compass(*cartesian), compass)
+
     def test_spherical_to_cartesian(self):
-        for cartesian, spherical, _ in self.combinations:
+        for cartesian, spherical, _, _ in self.combinations:
             testing.assert_almost_equal(axes.spherical_to_cartesian(*spherical), cartesian)
 
     def test_cylindrical_to_cartesian(self):
-        for cartesian, _, cylindrical in self.combinations:
+        for cartesian, _, cylindrical, _ in self.combinations:
             testing.assert_almost_equal(axes.cylindrical_to_cartesian(*cylindrical), cartesian)
 
     def test_polar_to_cartesian(self):
-        for cartesian, _, cylindrical in self.combinations:
+        for cartesian, _, cylindrical, _ in self.combinations:
             testing.assert_almost_equal(axes.polar_to_cartesian(*cylindrical[:2]), cartesian[:2])
+
+    def test_compass_to_cartesian(self):
+        for cartesian, _, _, compass in self.combinations:
+            testing.assert_almost_equal(axes.compass_to_cartesian(*compass), cartesian)
 
 
 class RotationMatrixTests(unittest.TestCase):

--- a/sapphire/tests/transformations/test_axes.py
+++ b/sapphire/tests/transformations/test_axes.py
@@ -10,16 +10,19 @@ class CoordinateSystemTests(unittest.TestCase):
     def setUp(self):
         """Test combinations of coordinates
 
-        Cartesian, spherical, cylindrical, and compass coordinates
+        Cartesian, spherical, cylindrical, polar, and compass coordinates
 
         """
         self.combinations = (
             ((0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0)),
-            ((1, 0, 0), (1, pi / 2., 0), (1, 0, 0), (1, 90, 0)),
-            ((0, 1, 0), (1, pi / 2., pi / 2.), (1, pi / 2., 0), (1, 0, 0)),
-            ((0, -1, 0), (1, pi / 2., -pi / 2.), (1, -pi / 2., 0), (1, 180, 0)),
-            ((1, 1, 1), (sqrt(3), arccos(1 / sqrt(3)), pi / 4.), (sqrt(2), pi / 4., 1), (sqrt(2), 45, 1)),
-            ((0, 0, 1), (1, 0, 0), (0, 0, 1), (0, 0, 1)))
+            ((1, 0, 0), (1, pi / 2, 0), (1, 0, 0), (1, 90, 0)),
+            ((-1, 0, 0), (1, pi / 2, pi), (1, pi, 0), (1, -90, 0)),
+            ((0, 1, 0), (1, pi / 2, pi / 2.), (1, pi / 2., 0), (1, 0, 0)),
+            ((0, -1, 0), (1, pi / 2, -pi / 2), (1, -pi / 2, 0), (1, 180, 0)),
+            ((0, 0, 1), (1, 0, 0), (0, 0, 1), (0, 0, 1)),
+            ((0, 0, -1), (1, pi, 0), (0, 0, -1), (0, 0, -1)),
+            ((1, 1, 1), (sqrt(3), arccos(1 / sqrt(3)), pi / 4), (sqrt(2), pi / 4, 1), (sqrt(2), 45, 1)),
+            ((-1, -1, -1), (sqrt(3), arccos(-1 / sqrt(3)), -pi * 3 / 4), (sqrt(2), -pi * 3 / 4, -1), (sqrt(2), -135, -1)))
 
     def test_cartesian_to_spherical(self):
         for cartesian, spherical, _, _ in self.combinations:

--- a/sapphire/transformations/axes.py
+++ b/sapphire/transformations/axes.py
@@ -1,8 +1,25 @@
 """ Perform various axes related transformations
 
-- Transformation between Cartesian, polar, cylindrical and spherical
+- Transformation between Cartesian, polar, cylindrical, spherical and compass
   coordinate systems.
 - Create a rotation matrix for rotations around a certain axis.
+
+Cartesian coordinates: x, y, z axes.
+
+Spherical coordinates:
+- r: length of vector.
+- theta: angle of the vector to the z-axis.
+- phi: angle of vector to the x-axis in x,y-plane, rotating counterclockwise.
+
+Cylindrical and polar coordinates:
+- r: length of vector in x,y-plane.
+- phi: angle of vector to the x-axis in x,y-plane, rotating counterclockwise.
+- z: height above x,y-plane.
+
+Compass coordinates:
+- r: length of vector in x,y-plane.
+- alpha: angle of vector to the y-axis in x,y-plane, rotating clockwise.
+- z: height above x,y-plane.
 
 """
 from numpy import sqrt, arctan2, arccos, sin, cos, matrix, radians, degrees

--- a/sapphire/transformations/axes.py
+++ b/sapphire/transformations/axes.py
@@ -58,7 +58,7 @@ def cartesian_to_compass(x, y, z):
 
     """
     r = sqrt(x * x + y * y)
-    alpha = degrees(arctan2(y, x))
+    alpha = degrees(arctan2(x, y))
 
     return r, alpha, z
 

--- a/sapphire/transformations/axes.py
+++ b/sapphire/transformations/axes.py
@@ -5,7 +5,7 @@
 - Create a rotation matrix for rotations around a certain axis.
 
 """
-from numpy import sqrt, arctan2, arccos, sin, cos, matrix
+from numpy import sqrt, arctan2, arccos, sin, cos, matrix, radians, degrees
 
 
 def cartesian_to_spherical(x, y, z):
@@ -49,6 +49,20 @@ def cartesian_to_polar(x, y):
     return r, phi
 
 
+def cartesian_to_compass(x, y, z):
+    """Converts Cartesian coordinates into compass coordinates
+
+    :param x,y,z: Cartesian coordinates
+    :return: tuple of compass coordinates (r, alpha, z),
+             with alpha in degrees.
+
+    """
+    r = sqrt(x * x + y * y)
+    alpha = degrees(arctan2(y, x))
+
+    return r, alpha, z
+
+
 def spherical_to_cartesian(r, theta, phi):
     """Convert spherical coordinates into Cartesian coordinates
 
@@ -83,6 +97,19 @@ def polar_to_cartesian(r, phi):
     """
     x, y, _ = cylindrical_to_cartesian(r, phi, 0)
     return x, y
+
+
+def compass_to_cartesian(r, alpha, z):
+    """Converts compass coordinates into Cartesian coordinates
+
+    :param r,alpha,z: compass coordinates, with alpha in degrees.
+    :return: tuple of cartesian coordinates (x, y, z).
+
+    """
+    x = sin(radians(alpha)) * r
+    y = cos(radians(alpha)) * r
+
+    return x, y, z
 
 
 def rotation_matrix(angle, axis='z'):

--- a/sapphire/utils.py
+++ b/sapphire/utils.py
@@ -5,6 +5,8 @@ The module contains some commonly functions and classes.
 """
 from __future__ import division
 
+from bisect import bisect_right
+
 from numpy import floor, ceil, round, arccos, cos, sin, pi
 from scipy.stats import norm
 from progressbar import ProgressBar, ETA, Bar, Percentage
@@ -58,6 +60,20 @@ def round_in_base(value, base):
     """Get nearest multiple of base to the value"""
 
     return base * round(value / base)
+
+
+def get_active_index(values, value):
+    """Get the index where the value fits.
+
+    :param values: sorted list of values (e.g. list of timestamps).
+    :param value: value for which to find the position (e.g. a timestamp).
+    :return: index into the values list.
+
+    """
+    idx = bisect_right(values, value, lo=0)
+    if idx == 0:
+        idx = 1
+    return idx - 1
 
 
 def gauss(x, N, mu, sigma):


### PR DESCRIPTION
PR for #63.

Add time awareness to Cluster objects. Allow setting a 'timestamps' and get station/detector positions relevant for that timestamp.

Todo:
- [x] Setting the timestamp for the cluster
- [x] Read station layout csv API
- [x] Initializing a station with multiple GPS (ENU) locations
- [x] Initializing detectors with multiple ENU locations
- [x] Activating the relevant positions
- [x] Still work when called with just one location..
- [x] Deal with stations without submitted layouts
- [x] Deal with (0, 0, 0) coordinates (*Removed from Source CSV on publicdb*).
- [x] Use 4D stations in reconstructions
- [ ] Speed up position retrieval for stations/detector by internally caching the values.
- [x] Tests
    - [x] Fix old tests
    - [x] Make some 4D tests
    - [x] Check if correct positions are used in reconstructions