### PR TITLE
Fix PEP8 in master: remove unused imports

### DIFF
--- a/sapphire/tests/analysis/test_landau.py
+++ b/sapphire/tests/analysis/test_landau.py
@@ -1,7 +1,6 @@
 import unittest
-import warnings
 
-from numpy import array, linspace
+from numpy import linspace
 
 from sapphire.analysis import landau
 


### PR DESCRIPTION
Fix PEP8 in master: remove unused imports:

$ flake8 --ignore=E501 --exclude=sapphire/transformations/geographic.py sapphire
sapphire/tests/analysis/test_landau.py:2:1: F401 'warnings' imported but unused
sapphire/tests/analysis/test_landau.py:4:1: F401 'array' imported but unused