### PR TITLE
Add support for the end status line for downloading

### DIFF
--- a/sapphire/esd.py
+++ b/sapphire/esd.py
@@ -204,6 +204,18 @@ def download_data(file, group, station_number, start=None, end=None,
     if progress:
         pbar.finish()
 
+    if line[0][0] == '#':
+        if len(line[0]) == 1:
+            # No events recieved, and no success line
+            raise Exception('Failed to download data, no data recieved.')
+        else:
+            # Successful download because last line is a non-empty comment
+            return
+    else:
+        # Last line is data, report failed download and date/time of last line
+        raise Exception('Failed to complete download, last received data '
+                        'from: %s %s.' % tuple(line[:2]))
+
 
 def download_coincidences(file, group='', cluster=None, stations=None,
                           start=None, end=None, n=2, progress=True):
@@ -305,6 +317,18 @@ def download_coincidences(file, group='', cluster=None, stations=None,
                                           station_groups)
     if progress:
         pbar.finish()
+
+    if line[0][0] == '#':
+        if len(line[0]) == 1:
+            # No events recieved, and no success line
+            raise Exception('Failed to download data, no data recieved.')
+        else:
+            # Successful download because last line is a non-empty comment
+            return
+    else:
+        # Last line is data, report failed download and date/time of last line
+        raise Exception('Failed to complete download, last received data '
+                        'from: %s %s.' % tuple(line[2:4]))
 
     file.flush()
 


### PR DESCRIPTION
On a successful download the last line should be a non-empty comment line.
If the last line is indeed a non-empty comment, do nothing.
If it is not raise an exception.
If the last line was an empty comment only the header was downloaded.
If the last line is data report the date/time of that data.

Related to HiSPARC/publicdb#128

TODO:
- Update tests to test failure
- If someone feels adventurous they can try to make the script start downloading again if it fully/partially failed.