### PR TITLE
Coriska reader: Use buffered IO for input stream

### DIFF
--- a/sapphire/corsika/blocks.py
+++ b/sapphire/corsika/blocks.py
@@ -14,7 +14,7 @@ import numpy
 
 import units
 import particles
-
+from numba import jit
 
 # All sizes are in bytes
 
@@ -381,6 +381,7 @@ class EventEnd(object):
         self.n_preshower_EM_particles = subblock[266]
 
 
+@jit(nopython=True)
 def particle_data(subblock):
     """Get particle data.
 

--- a/sapphire/corsika/mergesort.py
+++ b/sapphire/corsika/mergesort.py
@@ -85,6 +85,10 @@ class TableMergeSort(object):
         return self
 
     def __exit__(self, type, value, traceback):
+        try:
+            self.tempfile_path
+        except AttributeError:
+            return
         if self.hdf5_temp is not None:
             self.hdf5_temp.close()
             os.remove(self.tempfile_path)

--- a/sapphire/corsika/reader.py
+++ b/sapphire/corsika/reader.py
@@ -68,6 +68,7 @@
 from struct import unpack
 import warnings
 import os
+from io import open
 
 from .blocks import (RunHeader, RunEnd, EventHeader, EventEnd,
                      ParticleData, Format, ParticleDataThin, FormatThin,


### PR DESCRIPTION
I know this is just procrastinating, but I profiled conversion of DAT000000 to HDF5:
https://gist.github.com/tomkooij/74d2ef3276114bfb7ae159f9bfc7c602

A lot of time is spent in ```file.read``` and ```file.seek```.
This PR seems to solve that (somewhat) by using the python built-in BufferedIO. (I didn't know it existed).

I've only tested a 250 Mb file. It's about 30% faster. (2m40 -> 1m40). ```h5diff``` thinks the output files are identical.