### PR TITLE
Add gps_to_datetime and datetime_to_gps to global __init__.py

### DIFF
--- a/sapphire/__init__.py
+++ b/sapphire/__init__.py
@@ -83,7 +83,7 @@ from .simulations.groundparticles import (GroundParticlesSimulation,
 from .simulations.ldf import KascadeLdfSimulation, NkgLdfSimulation
 from .simulations.showerfront import FlatFrontSimulation, ConeFrontSimulation
 from .transformations.celestial import zenithazimuth_to_equatorial
-
+from .transformations.clock import gps_to_datetime, datetime_to_gps
 
 __all__ = ['analysis',
            'api',
@@ -116,5 +116,6 @@ __all__ = ['analysis',
            'GroundParticlesSimulation', 'MultipleGroundParticlesSimulation',
            'KascadeLdfSimulation', 'NkgLdfSimulation',
            'FlatFrontSimulation', 'ConeFrontSimulation',
-           'zenithazimuth_to_equatorial'
+           'zenithazimuth_to_equatorial',
+           'gps_to_datetime', 'datetime_to_gps'
            ]


### PR DESCRIPTION
Conversion of datetime to and from gps timestamps is a recurring task.
SAPPHiRE has well tested functions to do this. But they cumbersome to
import because they are in sapphire.transformations.clock
Allow:
```python
from sapphire import gps_to_datetime
from sapphire import datetime_to_gps
```