### PR TITLE
Handle (nan,nan) station timing offset in tests

### DIFF
--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -6,7 +6,7 @@ import warnings
 from os import path, extsep
 
 from mock import patch, sentinel
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from sapphire import api
 
@@ -568,7 +568,7 @@ class StationTests(unittest.TestCase):
         # Test omitting timestamp results in lastest offset
         data = self.station.station_timing_offset(ALT_STATION, FUTURE)
         data2 = self.station.station_timing_offset(ALT_STATION)
-        self.assertEqual(data, data2)
+        assert_equal(data, data2)
 
         # Zero offset to self
         data = self.station.station_timing_offset(STATION)

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -535,7 +535,7 @@ class StationTests(unittest.TestCase):
         self.assertEqual(len(offsets), 4)
         data = self.station.detector_timing_offset(FUTURE)
         data2 = self.station.detector_timing_offset()
-        self.assertEqual(data, data2)
+        assert_equal(data, data2)
 
     def test_station_timing_offsets(self):
         names = ('timestamp', 'offset', 'error')

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -7,7 +7,6 @@ from os import path, extsep
 
 from mock import patch, sentinel
 from numpy.testing import assert_allclose
-from numpy import nan_to_num
 
 from sapphire import api
 
@@ -569,7 +568,7 @@ class StationTests(unittest.TestCase):
         # Test omitting timestamp results in lastest offset
         data = self.station.station_timing_offset(ALT_STATION, FUTURE)
         data2 = self.station.station_timing_offset(ALT_STATION)
-        self.assertEqual(list(nan_to_num(data)), list(nan_to_num(data2)))
+        self.assertEqual(data, data2)
 
         # Zero offset to self
         data = self.station.station_timing_offset(STATION)

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -7,6 +7,7 @@ from os import path, extsep
 
 from mock import patch, sentinel
 from numpy.testing import assert_allclose
+from numpy import nan_to_num
 
 from sapphire import api
 
@@ -568,7 +569,7 @@ class StationTests(unittest.TestCase):
         # Test omitting timestamp results in lastest offset
         data = self.station.station_timing_offset(ALT_STATION, FUTURE)
         data2 = self.station.station_timing_offset(ALT_STATION)
-        self.assertEqual(data, data2)
+        self.assertEqual(list(nan_to_num(data)), list(nan_to_num(data2)))
 
         # Zero offset to self
         data = self.station.station_timing_offset(STATION)


### PR DESCRIPTION
unittest.TestCase.assertEqual cannot compare (nan, nan) tuples.
This makes test_api.test_station_timing_offsets fail if station
501 has offsets (nan, nan).
To fix it use numpy.nan_to_num to replace nan by 0. This casts
the tuples to numpy.ndarrays which still cannot be compared.
Hence we cast this to list.


This is an ugly fix for a stupid problem... Perhaps use `numpy.testing.assert_equal` ?