### PR TITLE
Test against python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_install:
   - conda config --add channels numba
 
 install:
-  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pytables numba
+  - conda create --yes -n build_env python=$TRAVIS_PYTHON_VERSION numpy scipy pytables numba
+  - source activate build_env
   - pip install coverage coveralls codecov
   - pip install -e .[dev]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda config --add channels conda-forge
-  - conda config --add channels numba
 
 install:
   - conda create --yes -n build_env python=$TRAVIS_PYTHON_VERSION numpy scipy pytables numba

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 
 sudo: false
 
@@ -17,6 +18,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update --yes conda
+  - conda config --yes --add channels conda-forge
 
 install:
   - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pytables numba

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda config --yes --add channels conda-forge
+  - conda config --add channels conda-forge
+  - conda config --add channels numba
 
 install:
   - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pytables numba


### PR DESCRIPTION
CPython 3.6 was released 23-12-2016.
python 3.6 should be in conda defaults channel when Anaconda 4.3 is released.
(expected end of jan 2017)

Use python 3.6 packages from conda-forge
Use numba package from numba channel