### PR TITLE
Fix get_detector_ids()

### DIFF
--- a/sapphire/analysis/event_utils.py
+++ b/sapphire/analysis/event_utils.py
@@ -182,7 +182,7 @@ def get_detector_ids(station=None, event=None):
 
     """
     if station is not None:
-        detector_ids = list(range(len(station.detectors)))
+        detector_ids = list(range(station.n_detectors()))
     elif event is not None:
         detector_ids = [i for i, ph in enumerate(event['pulseheights'])
                         if ph != -1]

--- a/sapphire/tests/analysis/test_event_utils.py
+++ b/sapphire/tests/analysis/test_event_utils.py
@@ -203,7 +203,7 @@ class GetDetectorIdsTests(unittest.TestCase):
     def test_get_detector_ids(self):
         self.assertEqual(event_utils.get_detector_ids(), list(range(4)))
         station = MagicMock()
-        station.detectors.__len__.return_value = 2
+        station.n_detectors.return_value = 2
         self.assertEqual(event_utils.get_detector_ids(station=station), list(range(2)))
         event = MagicMock()
         event.__getitem__.side_effect = lambda name: [10, 100, 40, -1]


### PR DESCRIPTION
sapphire.api.Station.detectors() was removed in 54dc4c9.
Fix usage of that method in get_detector_ids().
