### PR TITLE
Set the center of mass of clusters to (0,0,0).

### DIFF
--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -467,6 +467,11 @@ class BaseCluster(object):
                                       detectors, station_timestamps,
                                       detector_timestamps, number))
 
+    def set_center_off_mass_to_zero(self):
+        """Set the cluster center of mass to (0, 0, 0)"""
+        x, y, z = self.calc_center_of_mass_coordinates()
+        self.set_coordinates(-x, -y, -z, 0)
+
     @property
     def stations(self):
         return self._stations
@@ -851,6 +856,8 @@ class HiSPARCStations(CompassStations):
                 detector_ts = [0]
 
             self._add_station(enu, razbs, station_ts, detector_ts, station)
+
+        self.set_center_off_mass_to_zero()
 
         if len(missing_gps):
             warnings.warn('Could not get GPS location for stations: %s. '

--- a/sapphire/tests/test_api.py
+++ b/sapphire/tests/test_api.py
@@ -360,8 +360,8 @@ class StationTests(unittest.TestCase):
 
     def test_config(self):
         self.assertEqual(self.station.config()['detnum'], 501)
-        self.assertAlmostEqual(self.station.config(date(2011, 1, 1))['mas_ch1_current'],
-                         7.54901960784279)
+        self.assertAlmostEqual(self.station.config(
+            date(2011, 1, 1))['mas_ch1_current'], 7.54901960784279)
 
     def test_num_events(self):
         self.assertIsInstance(self.station.n_events(2004), int)

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -297,7 +297,6 @@ class StationTests(unittest.TestCase):
             self.assertAlmostEqual(actual_value, expected_value, msg=msg)
 
 
-
 class BaseClusterTests(unittest.TestCase):
     def test_add_station(self):
         with patch('sapphire.clusters.Station') as mock_station:
@@ -575,6 +574,7 @@ class SingleDiamondStationTests(unittest.TestCase):
         detectors = stations[0].detectors
         self.assertEqual(len(detectors), 4)
 
+
 class HiSPARCStationTests(unittest.TestCase):
     def setUp(self):
         self.cluster = clusters.HiSPARCStations([501, 508, 510],
@@ -583,6 +583,7 @@ class HiSPARCStationTests(unittest.TestCase):
     def test_zero_center_off_mass(self):
         center = self.cluster.calc_center_of_mass_coordinates()
         assert_array_almost_equal(center, [0., 0., 0.])
+
 
 class FlattenClusterTests(unittest.TestCase):
 

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 from math import pi, sqrt, atan2
 from numpy import array, nan
+from numpy.testing import assert_array_almost_equal
 
 import unittest
 
@@ -296,6 +297,7 @@ class StationTests(unittest.TestCase):
             self.assertAlmostEqual(actual_value, expected_value, msg=msg)
 
 
+
 class BaseClusterTests(unittest.TestCase):
     def test_add_station(self):
         with patch('sapphire.clusters.Station') as mock_station:
@@ -418,6 +420,16 @@ class BaseClusterTests(unittest.TestCase):
         x, y = cluster.calc_xy_center_of_mass_coordinates()
         self.assertAlmostEqual(x, 0)
         self.assertAlmostEqual(y, 0)
+
+    def test_set_center_off_mass_to_zero(self):
+        cluster = clusters.BaseCluster()
+        cluster._add_station((0, 0), 0, [((0, 5 * sqrt(3)), 'UD'),
+                                         ((0, 5 * sqrt(3) / 3), 'UD'),
+                                         ((-10, 0), 'LR'),
+                                         ((10, 0), 'LR')])
+        cluster.set_center_off_mass_to_zero()
+        center = cluster.calc_center_of_mass_coordinates()
+        assert_array_almost_equal(center, [0., 0., 0.])
 
     def test__distance(self):
         x = array([-5., 4., 3.])
@@ -563,6 +575,14 @@ class SingleDiamondStationTests(unittest.TestCase):
         detectors = stations[0].detectors
         self.assertEqual(len(detectors), 4)
 
+class HiSPARCStationTests(unittest.TestCase):
+    def setUp(self):
+        self.cluster = clusters.HiSPARCStations([501, 508, 510],
+                                                force_stale=True)
+
+    def test_zero_center_off_mass(self):
+        center = self.cluster.calc_center_of_mass_coordinates()
+        assert_array_almost_equal(center, [0., 0., 0.])
 
 class FlattenClusterTests(unittest.TestCase):
 


### PR DESCRIPTION
Set the center of mass of clusters (HiSPARCStation, HiSPARCNetwork,
ScienceParkCluster) to (0, 0, 0).

This is necessary for simulations, to make sure the clusters are rotated
around the correct axis.