### PR TITLE
Set center of masss to origin for rotated clusters

### DIFF
--- a/sapphire/clusters.py
+++ b/sapphire/clusters.py
@@ -467,10 +467,13 @@ class BaseCluster(object):
                                       detectors, station_timestamps,
                                       detector_timestamps, number))
 
-    def set_center_off_mass_to_zero(self):
+    def set_center_off_mass_at_origin(self):
         """Set the cluster center of mass to (0, 0, 0)"""
+        self.x = 0
+        self.y = 0
+        self.z = 0
         x, y, z = self.calc_center_of_mass_coordinates()
-        self.set_coordinates(-x, -y, -z, 0)
+        self.set_coordinates(-x, -y, -z, self.alpha)
 
     @property
     def stations(self):
@@ -857,7 +860,7 @@ class HiSPARCStations(CompassStations):
 
             self._add_station(enu, razbs, station_ts, detector_ts, station)
 
-        self.set_center_off_mass_to_zero()
+        self.set_center_off_mass_at_origin()
 
         if len(missing_gps):
             warnings.warn('Could not get GPS location for stations: %s. '

--- a/sapphire/tests/test_clusters.py
+++ b/sapphire/tests/test_clusters.py
@@ -420,15 +420,27 @@ class BaseClusterTests(unittest.TestCase):
         self.assertAlmostEqual(x, 0)
         self.assertAlmostEqual(y, 0)
 
-    def test_set_center_off_mass_to_zero(self):
+    def test_set_center_off_mass_at_origin(self):
         cluster = clusters.BaseCluster()
         cluster._add_station((0, 0), 0, [((0, 5 * sqrt(3)), 'UD'),
                                          ((0, 5 * sqrt(3) / 3), 'UD'),
                                          ((-10, 0), 'LR'),
                                          ((10, 0), 'LR')])
-        cluster.set_center_off_mass_to_zero()
+        cluster.set_center_off_mass_at_origin()
         center = cluster.calc_center_of_mass_coordinates()
         assert_array_almost_equal(center, [0., 0., 0.])
+
+    def test_set_center_off_mass_at_origin_rotated_cluster(self):
+        cluster = clusters.BaseCluster()
+        cluster._add_station((0, 0), 0, [((0, 5 * sqrt(3)), 'UD'),
+                                         ((0, 5 * sqrt(3) / 3), 'UD'),
+                                         ((-10, 0), 'LR'),
+                                         ((10, 0), 'LR')])
+        cluster.set_coordinates(10., -10., 1., 1.)
+        cluster.set_center_off_mass_at_origin()
+        center = cluster.calc_center_of_mass_coordinates()
+        assert_array_almost_equal(center, [0., 0., 0.])
+        self.assertAlmostEqual(cluster.alpha, 1.)
 
     def test__distance(self):
         x = array([-5., 4., 3.])


### PR DESCRIPTION
Handle rotated and translated clusters. Add test. Fixes some issues with #171.

Change set_center_of_mass_to_zero() to set_center_of_mass_at_origin()

