### PR TITLE
Use extended timestamp for ets0 baseline

### DIFF
--- a/sapphire/analysis/direction_reconstruction.py
+++ b/sapphire/analysis/direction_reconstruction.py
@@ -167,7 +167,7 @@ class CoincidenceDirectionReconstruction(object):
 
         # Subtract base timestamp to prevent loss of precision
         ts0 = int(coincidence_events[0][1]['timestamp'])
-        ets0 = ts0 * int(1e9)
+        ets0 = coincidence_events[0][1]['ext_timestamp']
         self.cluster.set_timestamp(ts0)
         t, x, y, z, nums = ([], [], [], [], [])
 
@@ -373,7 +373,8 @@ class CoincidenceDirectionReconstructionDetectors(
 
         # Subtract base timestamp to prevent loss of precision
         ts0 = int(coincidence_events[0][1]['timestamp'])
-        ets0 = ts0 * int(1e9)
+        ets0 = coincidence_events[0][1]['ext_timestamp']
+
         self.cluster.set_timestamp(ts0)
         t, x, y, z, nums = ([], [], [], [], [])
 


### PR DESCRIPTION
This is WIP. PR opened as a "TODO". Priority low.

In direction reconstruction of coincidences, the **station arrival times** are determined offset from the coincidence timestamp. This results in arrival times in nanoseconds with up to 9 significant digits, such as (worst case):

s1: 900000012
s2: 900000123
s3: 899999997

Converting such arrival times to floats could cause loss of precision. 

ToDo:
 - [ ] Add unittest that actually breaks floating point precision 
 - [ ] Test / compare with real life reconstructions
 - [ ] Fix unittests
 