### PR TITLE
Deprecation fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
     else
       MINICONDA=Miniconda3-latest-Linux-x86_64.sh;
     fi
-  - wget http://repo.continuum.io/miniconda/${MINICONDA} -O miniconda.sh
+  - wget --no-verbose http://repo.continuum.io/miniconda/${MINICONDA} -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update --yes conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ install:
   - if [ "$ASTROPY" = "yes" ]; then
       conda install --yes astropy;
     fi
-  - pip install coverage coveralls codecov
-  - pip install -e .[dev]
+  - pip install -e .[dev,coverage]
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 test: unittests flaketest doctest
 
 unittests:
-	coverage run setup.py test
+	coverage run setup.py test --quiet
 
 flaketest:
 	flake8 sapphire

--- a/sapphire/analysis/calibration.py
+++ b/sapphire/analysis/calibration.py
@@ -347,7 +347,7 @@ def determine_station_timing_offset(dt, dz=0):
     p = percentile(dt, [0.5, 99.5])
     # Bins should at least be 1 ns wide, on average at least 4 counts per bin
     # and at most 200 bins.
-    bins = linspace(p[0], p[1], min(int(p[1] - p[0]), len(dt) / 4, 200))
+    bins = linspace(p[0], p[1], min(int(p[1] - p[0]), len(dt) // 4, 200))
     station_offset, station_offset_error = fit_timing_offset(dt, bins)
     station_offset += dz / c
     if abs(station_offset) > 1000:

--- a/sapphire/tests/transformations/test_axes.py
+++ b/sapphire/tests/transformations/test_axes.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import arccos, matrix, pi, sqrt, testing
+from numpy import arccos, array, pi, sqrt, testing
 
 from sapphire.transformations import axes
 
@@ -76,7 +76,7 @@ class RotationMatrixTests(unittest.TestCase):
     def test_no_rotation_matrix(self):
         """Check if no rotation is correctly returned"""
 
-        no_rotation = matrix(((1, 0, 0), (0, 1, 0), (0, 0, 1)))
+        no_rotation = array(((1, 0, 0), (0, 1, 0), (0, 0, 1)))
         testing.assert_equal(axes.rotation_matrix(0, 'x'), no_rotation)
         testing.assert_equal(axes.rotation_matrix(0, 'y'), no_rotation)
         testing.assert_equal(axes.rotation_matrix(0, 'z'), no_rotation)
@@ -85,11 +85,11 @@ class RotationMatrixTests(unittest.TestCase):
         """Rotate by 90 degrees to swap the other two axes"""
 
         testing.assert_almost_equal(axes.rotation_matrix(pi / 2., 'x'),
-                                    matrix(((1, 0, 0), (0, 0, 1), (0, -1, 0))))
+                                    array(((1, 0, 0), (0, 0, 1), (0, -1, 0))))
         testing.assert_almost_equal(axes.rotation_matrix(pi / 2., 'y'),
-                                    matrix(((0, 0, -1), (0, 1, 0), (1, 0, 0))))
+                                    array(((0, 0, -1), (0, 1, 0), (1, 0, 0))))
         testing.assert_almost_equal(axes.rotation_matrix(pi / 2, 'z'),
-                                    matrix(((0, 1, 0), (-1, 0, 0), (0, 0, 1))))
+                                    array(((0, 1, 0), (-1, 0, 0), (0, 0, 1))))
 
 
 if __name__ == '__main__':

--- a/sapphire/transformations/axes.py
+++ b/sapphire/transformations/axes.py
@@ -22,7 +22,7 @@ Compass coordinates:
 - z: height above x,y-plane.
 
 """
-from numpy import arccos, arctan2, cos, degrees, array, radians, sin, sqrt
+from numpy import arccos, arctan2, array, cos, degrees, radians, sin, sqrt
 
 
 def cartesian_to_spherical(x, y, z):

--- a/sapphire/transformations/axes.py
+++ b/sapphire/transformations/axes.py
@@ -22,7 +22,7 @@ Compass coordinates:
 - z: height above x,y-plane.
 
 """
-from numpy import arccos, arctan2, cos, degrees, matrix, radians, sin, sqrt
+from numpy import arccos, arctan2, cos, degrees, array, radians, sin, sqrt
 
 
 def cartesian_to_spherical(x, y, z):
@@ -137,8 +137,8 @@ def rotate_cartesian(x, y, z, angle, axis='z'):
 
     """
     rot = rotation_matrix(angle, axis)
-    new = (x, y, z) * rot
-    return new.item(0), new.item(1), new.item(2)
+    new = rot.T.dot((x, y, z))
+    return tuple(new)
 
 
 def rotation_matrix(angle, axis='z'):
@@ -154,8 +154,8 @@ def rotation_matrix(angle, axis='z'):
     sina = sin(angle)
     cosa = cos(angle)
     if axis == 'z':
-        return matrix(((cosa, sina, 0), (-sina, cosa, 0), (0, 0, 1)))
+        return array(((cosa, sina, 0), (-sina, cosa, 0), (0, 0, 1)))
     elif axis == 'y':
-        return matrix(((cosa, 0, -sina), (0, 1, 0), (sina, 0, cosa)))
+        return array(((cosa, 0, -sina), (0, 1, 0), (sina, 0, cosa)))
     elif axis == 'x':
-        return matrix(((1, 0, 0), (0, cosa, sina), (0, -sina, cosa)))
+        return array(((1, 0, 0), (0, cosa, sina), (0, -sina, cosa)))

--- a/sapphire/transformations/geographic.py
+++ b/sapphire/transformations/geographic.py
@@ -6,7 +6,7 @@
 """
 from math import atan2, cos, degrees, radians, sin, sqrt
 
-from numpy import matrix
+from numpy import array
 
 
 class WGS84Datum(object):
@@ -149,14 +149,14 @@ class FromWGS84ToENUTransformation(object):
         lat = radians(latitude)
         lon = radians(longitude)
 
-        transformation = matrix([
+        transformation = array([
             [           -sin(lon),             cos(lon),       0.],  # noqa
             [-sin(lat) * cos(lon), -sin(lat) * sin(lon), cos(lat)],
             [ cos(lat) * cos(lon),  cos(lat) * sin(lon), sin(lat)]])  # noqa
 
-        coordinates = matrix([[x - xr], [y - yr], [z - zr]])
+        coordinates = array([[x - xr], [y - yr], [z - zr]])
 
-        return (transformation * coordinates).A1
+        return transformation.dot(coordinates)
 
     def enu_to_ecef(self, coordinates):
         """Convert from ENU coordinates to ECEF coordinates
@@ -174,12 +174,12 @@ class FromWGS84ToENUTransformation(object):
         lat = radians(latitude)
         lon = radians(longitude)
 
-        transformation = matrix([
+        transformation = array([
             [-sin(lon), -sin(lat) * cos(lon), cos(lat) * cos(lon)],
             [ cos(lon), -sin(lat) * sin(lon), cos(lat) * sin(lon)],  # noqa
             [       0.,             cos(lat),            sin(lat)]])  # noqa
 
-        x, y, z = (transformation * matrix(coordinates).T).A1
+        x, y, z = transformation.dot(array(coordinates))
 
         return x + xr, y + yr, z + zr
 

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,6 @@ setup(name='hisparc-sapphire',
                         'progressbar2>=3.7.0', 'lazy', 'mock', 'six'],
       extras_require={
           'dev': ['Sphinx', 'flake8', 'pep8-naming', 'coverage', 'flake8-isort'],
+          'coverage': ['coveralls', 'codecov'],
           'astropy': ["astropy"]},
       test_suite="sapphire.tests",)


### PR DESCRIPTION
These issues showed up as warnings during tests.

> PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.

> DeprecationWarning: object of type <class 'float'> cannot be safely interpreted as an integer.